### PR TITLE
whisper-fill: Avoid functional programing

### DIFF
--- a/bin/rrd2whisper.py
+++ b/bin/rrd2whisper.py
@@ -75,9 +75,8 @@ else:
     rra_info['xff'] = rrd_info['rra[%d].xff' % i]
     rras.append(rra_info)
 
-datasources = []
 if 'ds' in rrd_info:
-  datasource_names = rrd_info['ds'].keys()
+  datasources = rrd_info['ds'].keys()
 else:
   ds_keys = [key for key in rrd_info if key.startswith('ds[')]
   datasources = list(set(key[3:].split(']')[0] for key in ds_keys))

--- a/bin/whisper-fill.py
+++ b/bin/whisper-fill.py
@@ -75,11 +75,9 @@ def fill(src, dst, tstart, tstop):
 
         (timeInfo, values) = fetch(src, fromTime, untilTime)
         (start, end, archive_step) = timeInfo
-        pointsToWrite = list(itertools.ifilter(
-            lambda points: points[1] is not None,
-            itertools.izip(xrange(start, end, archive_step), values)))
-        # order points by timestamp, newest first
-        pointsToWrite.sort(key=lambda p: p[0], reverse=True)
+        pointsToWrite = [(end-n*archive_step, values[-n])
+                         for n in xrange(1, (end-start)//archive_step + 1)
+                         if values[-n] is not None]
         update_many(dst, pointsToWrite)
 
         tstop = fromTime


### PR DESCRIPTION
This make a synthetic benchmark doing 1000 fills of 10000 points 15%
faster from 22.0 seconds to 18.6 seconds (best of three measurements for
both points)

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/criteo-forks/whisper/3)

<!-- Reviewable:end -->
