### PR TITLE
Avoid double sorting points

### DIFF
--- a/bin/rrd2whisper.py
+++ b/bin/rrd2whisper.py
@@ -75,9 +75,8 @@ else:
     rra_info['xff'] = rrd_info['rra[%d].xff' % i]
     rras.append(rra_info)
 
-datasources = []
 if 'ds' in rrd_info:
-  datasource_names = rrd_info['ds'].keys()
+  datasources = rrd_info['ds'].keys()
 else:
   ds_keys = [key for key in rrd_info if key.startswith('ds[')]
   datasources = list(set(key[3:].split(']')[0] for key in ds_keys))

--- a/bin/whisper-fill.py
+++ b/bin/whisper-fill.py
@@ -75,11 +75,9 @@ def fill(src, dst, tstart, tstop):
 
         (timeInfo, values) = fetch(src, fromTime, untilTime)
         (start, end, archive_step) = timeInfo
-        pointsToWrite = list(itertools.ifilter(
-            lambda points: points[1] is not None,
-            itertools.izip(xrange(start, end, archive_step), values)))
-        # order points by timestamp, newest first
-        pointsToWrite.sort(key=lambda p: p[0], reverse=True)
+        pointsToWrite = [(end-n*archive_step, values[-n])
+                         for n in xrange(1, (end-start)//archive_step + 1)
+                         if values[-n] is not None]
         update_many(dst, pointsToWrite)
 
         tstop = fromTime

--- a/bin/whisper-fill.py
+++ b/bin/whisper-fill.py
@@ -78,7 +78,7 @@ def fill(src, dst, tstart, tstop):
         pointsToWrite = [(end-n*archive_step, values[-n])
                          for n in xrange(1, (end-start)//archive_step + 1)
                          if values[-n] is not None]
-        update_many(dst, pointsToWrite)
+        update_many(dst, pointsToWrite, points_reverse_sorted=True)
 
         tstop = fromTime
 

--- a/whisper.py
+++ b/whisper.py
@@ -609,15 +609,18 @@ def file_update(fh, value, timestamp):
     os.fsync(fh.fileno())
 
 
-def update_many(path, points):
+def update_many(path, points, points_reverse_sorted=False):
   """update_many(path,points)
 
 path is a string
 points is a list of (timestamp,value) points
+points_reverse_sorted is a boolean, if true points values are assumed to be float, timestamps are assumed
+to be int and they are assumed to be storted by decreasing timestamps
 """
   if not points: return
-  points = [(int(t), float(v)) for (t, v) in points]
-  points.sort(key=lambda p: p[0], reverse=True)  # Order points by timestamp, newest first
+  if not points_reverse_sorted:
+      points = [(int(t), float(v)) for (t, v) in points]
+      points.sort(key=lambda p: p[0], reverse=True)  # Order points by timestamp, newest first
   with open(path, 'r+b') as fh:
     return file_update_many(fh, points)
 


### PR DESCRIPTION
This make a synthetic benchmark doing 1000 merge of 10000 points 15%
faster from 18.6 seconds to 15.8 seconds (best of three measurements
for both points)

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/criteo-forks/whisper/4)

<!-- Reviewable:end -->
